### PR TITLE
Core: fix Label line break mode in Gtk

### DIFF
--- a/src/Core/src/Core/ILabel.cs
+++ b/src/Core/src/Core/ILabel.cs
@@ -6,6 +6,16 @@ namespace Microsoft.Maui
 	public interface ILabel : IView, IText, ITextAlignment, IPadding
 	{
 		/// <summary>
+		/// Gets the option for line breaking.
+		/// </summary>
+		LineBreakMode LineBreakMode { get; }
+
+		/// <summary>
+		/// Gets the maximum number of lines allowed in the Label.
+		/// </summary>
+		int MaxLines { get; }
+		
+		/// <summary>
 		/// Gets the text decoration applied to the Label.
 		/// Underline and strike-through text decorations can be applied.
 		/// </summary>

--- a/src/Core/src/Handlers/Label/LabelHandler.Gtk.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Gtk.cs
@@ -55,8 +55,8 @@ namespace Microsoft.Maui.Handlers
 				SharedTextLayout.TextFlow = TextFlow.ClipBounds;
 				SharedTextLayout.HorizontalAlignment = virtualView.HorizontalTextAlignment.GetHorizontalAlignment();
 				SharedTextLayout.VerticalAlignment = virtualView.VerticalTextAlignment.GetVerticalAlignment();
-
-				// SharedTextLayout.LineBreakMode = virtualView.LineBreakMode.GetLineBreakMode();
+				
+				SharedTextLayout.LineBreakMode = virtualView.LineBreakMode.GetLineBreakMode();
 
 				var heightForWidth = !heightConstrained;
 

--- a/src/Core/src/Handlers/Label/LabelHandler.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.cs
@@ -39,6 +39,10 @@ namespace Microsoft.Maui.Handlers
 			[nameof(ILabel.Text)] = MapText,
 			[nameof(ITextStyle.TextColor)] = MapTextColor,
 			[nameof(ILabel.TextDecorations)] = MapTextDecorations,
+#if GTK			
+			[nameof(ILabel.LineBreakMode)] = MapLineBreakMode,
+			[nameof(ILabel.MaxLines)] = MapMaxLines,
+#endif
 		};
 
 		public static CommandMapper<IActivityIndicator, ILabelHandler> CommandMapper = new(ViewCommandMapper)

--- a/src/Core/src/Platform/Gtk/LabelExtensions.cs
+++ b/src/Core/src/Platform/Gtk/LabelExtensions.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Maui
 
 		public static void UpdateMaxLines(this Label nativeLabel, ILabel label)
 		{
-			// nativeLabel.Lines = label.MaxLines;
+			nativeLabel.Lines = label.MaxLines;
 			nativeLabel.AdjustMaxLines();
 
 		}
@@ -111,8 +111,8 @@ namespace Microsoft.Maui
 
 		public static void UpdateLineBreakMode(this Label nativeLabel, ILabel label)
 		{
-			var labelLineBreakMode = LineBreakMode.CharacterWrap;
-			var labelMaxLines = 0;
+			var labelLineBreakMode = label.LineBreakMode;
+			var labelMaxLines = label.MaxLines;
 			
 			switch (labelLineBreakMode)
 			{


### PR DESCRIPTION
Made label widget in Gtk respect LineBreakMode and MaxLines
properties, the way it does on other platforms.
These properties were added to ILabel interface, as it is in
MAUI main branch.